### PR TITLE
Properly escape extra_tags in user type

### DIFF
--- a/aioinflux/serialization/usertype.py
+++ b/aioinflux/serialization/usertype.py
@@ -125,7 +125,7 @@ def _make_serializer(meas, schema, extra_tags, placeholder):  # noqa: C901
             raise SchemaError(f"Invalid attribute type {k!r}: {t!r}")
     extra_tags = extra_tags or {}
     for k, v in extra_tags.items():
-        tags.append(f"{k}={v}")
+        tags.append(f"{k}={v.translate(tag_escape)}")
     if placeholder:
         fields.insert(0, f"_=true")
 


### PR DESCRIPTION
When adding extra_tags to a user defined object the extra tags are not properly escaped to line protocol.  This PR ensures the tag value is escaped, reusing the existing `tag_escape` implementation.  I did not alter the tag name but I'd be fine adding that in as well if requested.