### PR TITLE
serialisation.mapping - bugfix datetime objects

### DIFF
--- a/aioinflux/serialization/__init__.py
+++ b/aioinflux/serialization/__init__.py
@@ -19,6 +19,7 @@ def serialize(data, measurement=None, tag_columns=None, **extra_tags):
     elif isinstance(data, dict):
         return mapping.serialize(data, measurement, **extra_tags)
     elif hasattr(data, '__iter__'):
-        return b'\n'.join([serialize(i, measurement, tag_columns, **extra_tags) for i in data])
+        return b'\n'.join([serialize(i, measurement, tag_columns, **extra_tags)
+                           for i in data])
     else:
         raise ValueError('Invalid input', data)

--- a/aioinflux/serialization/mapping.py
+++ b/aioinflux/serialization/mapping.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 from typing import Mapping
 
 import ciso8601
@@ -47,11 +48,13 @@ def _serialize_timestamp(point):
         dt = ciso8601.parse_datetime(dt)
         if not dt:
             raise ValueError(f'Invalid datetime string: {dt!r}')
-
-    if not dt.tzinfo:
+    elif isinstance(dt, datetime):
+        if dt.tzinfo:
+            return int((dt - dt.tzinfo.utcoffset(dt)).timestamp() * 10**9)
         # Assume tz-naive input to be in UTC, not local time
-        return int(dt.timestamp() - time.timezone) * 10 ** 9 + dt.microsecond * 1000
-    return int(dt.timestamp()) * 10 ** 9 + dt.microsecond * 1000
+        return int(dt.timestamp() * 10**9)
+
+    raise AttributeError('time is an unknown type %s', type(dt))
 
 
 def _serialize_fields(point):


### PR DESCRIPTION
`datetime` objects were handled incorrectly. This resulted in a time offset from UTC.

This correct implementation assumes UTC time, if no `tzinfo` object is attached to the `datetime`.
Further the offset is now taken from the `tzinfo` object.