### PR TITLE
Add support for other np.floatX types than np.float64

### DIFF
--- a/aioinflux/serialization/dataframe.py
+++ b/aioinflux/serialization/dataframe.py
@@ -104,7 +104,7 @@ def serialize(df, measurement, tag_columns=None, **extra_tags) -> bytes:
             tags.append(f"{k}={{p[{i+1}]}}")
         elif issubclass(v.type, np.integer):
             fields.append(f"{k}={{p[{i+1}]}}i")
-        elif issubclass(v.type, (np.float, np.bool_)):
+        elif issubclass(v.type, (np.float, np.bool_, np.floating)):
             fields.append(f"{k}={{p[{i+1}]}}")
         else:
             # String escaping is skipped for performance reasons

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import pytest
 import testing_utils as utils
 from testing_utils import logger
@@ -105,6 +106,18 @@ async def test_change_db(client):
     await client.ping()
 
     client.db, client.output = state
+
+
+@utils.requires_pandas
+@pytest.mark.asyncio
+async def test_serialize_float():
+    """Test various dtypes which should all result into float serialization"""
+    from aioinflux.serialization.dataframe import serialize
+
+    for type_ in [float, np.float, np.float16, np.float32, np.float64, np.float128]:
+        df = pd.DataFrame([{'a': 3.5}], index=[datetime.now()], dtype=type_)
+        res = serialize(df, measurement='test_serialize')
+        assert b'a=3.5' in res
 
 
 ###############


### PR DESCRIPTION
Trying to fix the serialisation of other precisions than the default np.float64. I found out while importing a big dataset and trying to use np.float32 for some values to save memory, that it was serialised as string...

In fact `issubclass(np.float32, np.float)` returns false, same for float16, and float128. Only float and float64 works currently. And `np.floating` covers for everything except (surprisingly) `np.float`... Checking both looks to be the safest way to me.
